### PR TITLE
Guassian model performance improvements

### DIFF
--- a/examples/gaussian.jl
+++ b/examples/gaussian.jl
@@ -6,7 +6,7 @@ using Random: seed!
 seed!(1234)
 
 
-
+using Profile
 
 # ===
 # PARAMETERS
@@ -65,17 +65,18 @@ masked_sampler = MaskedSampler(base_sampler, masks; masked_data=masked_data, num
 sampler = Annealer(masked_sampler, 200.0, :cluster_amplitude_var; num_samples=3)
 
 # Run sampler
-results = sampler(model, unmasked_data)
-sampled_data, sampled_assignments = sample_masked_data(model, masks)
+# results = 
+@time sampler(model, unmasked_data)
+# sampled_data, sampled_assignments = sample_masked_data(model, masks)
 
-new_results = base_sampler(model, unmasked_data; initial_assignments=last(results.assignments))
+# new_results = base_sampler(model, unmasked_data; initial_assignments=last(results.assignments))
 
-# Visualize results
-p2 = plot(
-    unmasked_data, last(results.assignments);
-    size=(400, 400), xlim=(0, 2), ylim=(0, 2), title="estimate"
-)
-plot!(p2, masks)
-plot!(p2, sampled_data, color="red")
+# # Visualize results
+# p2 = plot(
+#     unmasked_data, last(results.assignments);
+#     size=(400, 400), xlim=(0, 2), ylim=(0, 2), title="estimate"
+# )
+# plot!(p2, masks)
+# plot!(p2, sampled_data, color="red")
 
-plot(p1, p2, layout=(1, 2), size=(800, 400))
+# plot(p1, p2, layout=(1, 2), size=(800, 400))

--- a/src/core/interface.jl
+++ b/src/core/interface.jl
@@ -64,8 +64,7 @@ set_posterior!(model::NeymanScottModel, k::Int) = nothing
 (OPTIONAL) Returns `true` if `x` is so far away from `cluster` that, with
 high certainty, `cluster` is not the parent of `x`.
 """
-too_far(x::AbstractDatapoint, cluster::AbstractCluster, model::NeymanScottModel) =
-    (norm(position(cluster) .- position(x)) > max_cluster_radius(model))
+too_far(x::AbstractDatapoint, cluster::AbstractCluster, model::NeymanScottModel) = false
 
 """
 (OPTIONAL) Summarize clusters and return a list of simpler structs 
@@ -223,15 +222,15 @@ complement_masks(masks::Vector{<: AbstractMask}, model::NeymanScottModel) =
 The integrated background intensity in the masked off region. If the background intensity
 is uniform, there is no need to override this method.
 """
-integrated_bkgd_intensity(model::NeymanScottModel, mask::AbstractMask) =
-    bkgd_rate(model.globals) * volume(mask)
+integrated_bkgd_intensity(model::NeymanScottModel, masks::Vector{<: AbstractMask}) =
+    bkgd_rate(model.globals) * sum(volume.(masks))
 
 """
 (OPTIONAL) The integrated cluster intensity in the masked off region. If left unimplemented, 
 this will approximate the cluster intensity using random samples.
 """
-integrated_cluster_intensity(model::NeymanScottModel, cluster::AbstractCluster,  mask::AbstractMask) = 
-    _integrated_cluster_intensity(model, cluster, mask)
+integrated_cluster_intensity(model::NeymanScottModel, cluster::AbstractCluster, masks::Vector{<: AbstractMask}) = 
+    _integrated_cluster_intensity(model, cluster, masks)
 
 
 """

--- a/src/core/mask.jl
+++ b/src/core/mask.jl
@@ -65,11 +65,9 @@ function log_like(
 
     # == SECOND TERM == #
     # -- Penalty on integrated intensity function -- #
-    for mask in masks        
-        ll -= integrated_bkgd_intensity(model, mask)
-        for ψ in clusters(model)
-            ll -= integrated_cluster_intensity(model, ψ, mask)
-        end
+    ll -= integrated_bkgd_intensity(model, masks)
+    for ψ in clusters(model)
+        ll -= integrated_cluster_intensity(model, ψ, masks)
     end
 
     return ll
@@ -91,10 +89,10 @@ Integrate the intensity of a cluster in the masked region.
 function _integrated_cluster_intensity(
     model::NeymanScottModel,
     cluster::AbstractCluster,
-    mask::AbstractMask;
+    masks::Vector{<: AbstractMask};
     num_samples = 1000
 )
-    num_in_mask = count(i -> (sample_datapoint(cluster, model) ∈ mask), 1:num_samples)
+    num_in_mask = count(i -> (sample_datapoint(cluster, model) ∈ masks), 1:num_samples)
     prob_in_mask = sum(num_in_mask) / num_samples
     return prob_in_mask * amplitude(cluster)
 end


### PR DESCRIPTION
Three major changes, which reduced the runtime of the little Gaussian example from ~30 seconds to ~13 seconds.
- Reduced the amount of sampling in `log_like(model, data, masks)` by sampling once per event and computing the integrated area of all the masks.
- Made `cluster.sampled_position` and `cluster.sampled_variance` static arrays instead of regular arrays, which allowed the compiler to 'compile away' various memory allocations and computations during sampling.
- Cached some of the sufficient statistics (this didn't help as much as I'd hoped)

10.5 ns / sample /  datapoint